### PR TITLE
Tweaked load test volumes to show increased order rates

### DIFF
--- a/deploy/kubernetes/demo-env-scripts/03-deploy-high-load.sh
+++ b/deploy/kubernetes/demo-env-scripts/03-deploy-high-load.sh
@@ -4,6 +4,6 @@ echo "Scaling up load"
 
 URL=http://$(kubectl get services -n sock-shop front-end -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 
-kubectl patch configmap/loadtest-configmap -n loadtest --type merge -p '{"data":{"TARGET_HOST":"'"$URL"'","CLIENTS":"15","HATCH_RATE":"15","NUM_REQUEST":"20"}}'
+kubectl patch configmap/loadtest-configmap -n loadtest --type merge -p '{"data":{"TARGET_HOST":"'"$URL"'","CLIENTS":"4","HATCH_RATE":"4","NUM_REQUEST":"80"}}'
 
 kubectl rollout restart deployment load-test -n loadtest

--- a/deploy/kubernetes/demo-env-scripts/04-deploy-normal-load.sh
+++ b/deploy/kubernetes/demo-env-scripts/04-deploy-normal-load.sh
@@ -4,6 +4,6 @@ echo "Scaling down load"
 
 URL=http://$(kubectl get services -n sock-shop front-end -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 
-kubectl patch configmap/loadtest-configmap -n loadtest --type merge -p '{"data":{"TARGET_HOST":"'"$URL"'","CLIENTS":"2","HATCH_RATE":"2","NUM_REQUEST":"8"}}'
+kubectl patch configmap/loadtest-configmap -n loadtest --type merge -p '{"data":{"TARGET_HOST":"'"$URL"'","CLIENTS":"1","HATCH_RATE":"1","NUM_REQUEST":"8"}}'
 
 kubectl rollout restart deployment load-test -n loadtest


### PR DESCRIPTION
The load tests were increasing QPS on the front end but not order volumes.  If we are to simulate breaks under load then this will allow us to do so more effectively.

To Validate:
In the Overview metrics dashboard in Sock Shop DEV, look at the past 24 hours and see the spikes in front end traffic twice per day and the corresponding rise in order service traffic and volume.