### PR TITLE
Update otel-collector.yaml

### DIFF
--- a/deploy/kubernetes/manifests-tracing/otel-collector.yaml
+++ b/deploy/kubernetes/manifests-tracing/otel-collector.yaml
@@ -108,7 +108,6 @@ data:
         Authorization: Bearer ${LOGZIO_METRICS_TOKEN}
     prometheus:
       endpoint: "localhost:8889"
-      namespace: "atm"
     logging:
   processors:
     batch:


### PR DESCRIPTION
Removing Namespace "atm" from span metrics names so it will match the SPM feature in jaeger.
so atm_calls_total
will be calls_total

- Read the contribution guidelines
- Include a reference to a related issue in this repository
- A description of the changes proposed in the pull request